### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/misfortune.cabal
+++ b/misfortune.cabal
@@ -2,7 +2,7 @@ name:                   misfortune
 version:                0.1.1.2
 stability:              experimental
 
-cabal-version:          >= 1.6
+cabal-version:          >= 1.8
 build-type:             Simple
 
 author:                 James Cook <mokus@deepbondi.net>


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: misfortune.cabal:110:37: version operators used. To use version                                                                                                                                                                                                           
operators the package needs to specify at least 'cabal-version: >= 1.8'.    
```